### PR TITLE
Update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Finance", "Asset"]
 license = "MIT"
 desc = "Financial assets"
 authors = ["Eric Forgy <Eric.Forgy@cavalre.com>", "ScottPJones <scottjones@alum.mit.edu>"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 Currencies = "0fd90b74-7c1f-579e-9252-02cd883047b9"

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -4,7 +4,8 @@ Assets
 This package provides implementations of `Instrument` for various financial assets:
 
 - `Cash`: which is based on a particular currency type, along with the minor unit.
-- `ListedStock`: which represents common stock listed on an exchange.
+- `Stock`: which represents a general common stock.
+- `ListedStock`: which represents a common stock listed on an exchange.
 
 It also provides a specialized `Position` for `Cash` that uses the currencies minor unit.
 
@@ -38,9 +39,20 @@ function Position{Cash{C,N}}(a) where {C,N}
 end
 
 """
-`ListedStock` is an implementation of `Instrument` represented by a singleton type with the exchange it is listed and its symbol, e.g. `ListedStock{:NASDAQ,:MSFT,:USD}`
+`Stock` is an implementation of a simple `Instrument` represented by a singleton type with a stock symbol and currency, e.g. `Stock{:MSFT,:USD}`. The currency can be omitted and it will default to USD, e.g. `Stock(:MSFT)`.
 """
-struct ListedStock{E,S,C} <: Instrument{S,Currency{C}} end
+struct Stock{S,C} <: Instrument{S,Currency{C}}
+    Stock(S::Symbol) = new{S,:USD}()
+    Stock(S::Symbol,C::Symbol) = new{S,C}()
+end
+
+"""
+`ListedStock` is an implementation of `Instrument` represented by a singleton type with the exchange it's listed, its symbol and its currency, e.g. `ListedStock{:NASDAQ,:MSFT,:USD}`. The currency can be omitted and it will default to USD, e.g. `ListedStock(:NASDAQ,:MSFT)`.
+"""
+struct ListedStock{E,S,C} <: Instrument{S,Currency{C}}
+    ListedStock(E::Symbol, S::Symbol) = new{E,S,:USD}()
+    ListedStock(E::Symbol, S::Symbol, C::Symbol) = new{E,S,C}()
+end
 
 # Set up short names for all of the currencies (as instances of the Cash instruments). This is really done as a convenience
 for (s,(ccy,u,c,n)) in Currencies.allpairs()

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -1,13 +1,12 @@
 """
 Assets
 
-This package provides various types to represent certain financial assets:
+This package provides implementations of `Instrument` for various financial assets:
 
-    `Cash`: which is based on a particular currency type, along with the minor unit
-    `ListedEquity`: which represents some form of equity such as a stock, that is listed
-                    on a particular exchange.
+- `Cash`: which is based on a particular currency type, along with the minor unit.
+- `ListedStock`: which represents common stock listed on an `Exchange`.
 
-It also provides methods for Position of Cash (such as for a bank account).
+It also provides a specialized `Position` for `Cash` that uses the currencies minor unit.
 
 See README.md for the full documentation
 
@@ -17,25 +16,21 @@ Licensed under MIT License, see LICENSE.md
 """
 module Assets
 
-using Currencies, Instruments, FixedPointDecimals
-import Instruments: Position, currency, symbol, unit, code, name
+using Currencies, FixedPointDecimals
+using Instruments: Instrument; import Instruments: Position, symbol, currency, unit, code, name
 
-export Cash, ListedEquity
+export Cash, ListedStock
 
 """
-`Cash` is a financial instrument represented by a singleton type with its currency symbol and the number of digits in the minor units, typically 0, 2, or 3, as parameters.
+`Cash` is an implementation of `Instrument` represented by a singleton type with its currency symbol and the number of digits in the minor units, typically 0, 2, or 3, as parameters.
 """
 struct Cash{S, N} <: Instrument{S,Currency{S}} end
 Cash(S::Symbol) = Cash{S,unit(S)}()
 Cash(::Currency{S}) where {S} = Cash(S)
 
-unit(::Cash{C,N}) where {C,N} = N
-symbol(::Cash{C}) where {C} = C
-currency(::Cash{C}) where {C} = currency(C)
-code(::Cash{C}) where {C} = code(C)
-name(::Cash{C}) where {C} = name(C)
-
-Base.show(io::IO, ::Cash{C}) where {C} = print(io, string(C))
+unit(::Cash{S,N}) where {S,N} = N
+code(::Cash{S}) where {S} = code(S)
+name(::Cash{S}) where {S} = name(S)
 
 function Position{Cash{C,N}}(a) where {C,N}
     T = FixedDecimal{Int,N}
@@ -43,17 +38,11 @@ function Position{Cash{C,N}}(a) where {C,N}
 end
 
 """
-`ListedEquity` is a financial instrument represented by a singleton type with the exchange it is listed on, and its symbol (such as :MSFT)
+`ListedStock` is an implementation of `Instrument` represented by a singleton type with the exchange it is listed and its symbol, e.g. `ListedStock{:NASDAQ,:MSFT,:USD}`
 """
-struct ListedEquity{E,C,S} <: Instrument{C,S}
-    ListedEquity(E, C, S::Symbol) = new{E,C,S}()
-end
-currency(::ListedEquity{E,S,C}) where {E,S,C} = currency(C)
-symbol(::ListedEquity{E,S}) where {E,S} = S
+struct ListedStock{E,S,C} <: Instrument{S,Currency{C}} end
 
-# Set up short names for all of the currencies (as instances of the Cash instruments)
-# This is really done as a convenience
-
+# Set up short names for all of the currencies (as instances of the Cash instruments). This is really done as a convenience
 for (s,(ccy,u,c,n)) in Currencies.allpairs()
     @eval const $s = Cash($ccy)
 end

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -5,7 +5,6 @@ This package provides implementations of `Instrument` for various financial asse
 
 - `Cash`: which is based on a particular currency type, along with the minor unit.
 - `Stock`: which represents a general common stock.
-- `ListedStock`: which represents a common stock listed on an exchange.
 
 It also provides a specialized `Position` for `Cash` that uses the currency's minor unit.
 
@@ -20,12 +19,14 @@ module Assets
 using Currencies, FixedPointDecimals
 using Instruments: Instrument; import Instruments: Position, symbol, currency, unit, code, name
 
-export Cash, ListedStock
+export Cash, Stock
 
 """
 `Cash` is an implementation of `Instrument` represented by a singleton type with its currency symbol and the number of digits in the minor units, typically 0, 2, or 3, as parameters.
 """
-struct Cash{S, N} <: Instrument{S,Currency{S}} end
+struct Cash{S, N} <: Instrument{S,Currency{S}} 
+    Cash{S,N}() where {S,N} = unit(S) === N ? new{S,N}() : error("Currency minor unit does not match.")
+end
 Cash(S::Symbol) = Cash{S,unit(S)}()
 Cash(::Type{Currency{S}}) where {S} = Cash(S)
 Cash(::Currency{S}) where {S} = Cash(S)
@@ -45,14 +46,6 @@ end
 struct Stock{S,C} <: Instrument{S,Currency{C}}
     Stock(S::Symbol) = new{S,:USD}()
     Stock(S::Symbol,C::Symbol) = new{S,C}()
-end
-
-"""
-`ListedStock` is an implementation of `Instrument` represented by a singleton type with the exchange it's listed, its symbol and its currency, e.g. `ListedStock{:NASDAQ,:MSFT,:USD}`. The currency can be omitted and it will default to USD, e.g. `ListedStock(:NASDAQ,:MSFT)`.
-"""
-struct ListedStock{E,S,C} <: Instrument{S,Currency{C}}
-    ListedStock(E::Symbol, S::Symbol) = new{E,S,:USD}()
-    ListedStock(E::Symbol, S::Symbol, C::Symbol) = new{E,S,C}()
 end
 
 # Set up short names for all of the currencies (as instances of the Cash instruments). This is really done as a convenience

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -7,7 +7,7 @@ This package provides implementations of `Instrument` for various financial asse
 - `Stock`: which represents a general common stock.
 - `ListedStock`: which represents a common stock listed on an exchange.
 
-It also provides a specialized `Position` for `Cash` that uses the currencies minor unit.
+It also provides a specialized `Position` for `Cash` that uses the currency's minor unit.
 
 See README.md for the full documentation
 

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -4,7 +4,7 @@ Assets
 This package provides implementations of `Instrument` for various financial assets:
 
 - `Cash`: which is based on a particular currency type, along with the minor unit.
-- `ListedStock`: which represents common stock listed on an `Exchange`.
+- `ListedStock`: which represents common stock listed on an exchange.
 
 It also provides a specialized `Position` for `Cash` that uses the currencies minor unit.
 

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -27,6 +27,7 @@ export Cash, ListedStock
 """
 struct Cash{S, N} <: Instrument{S,Currency{S}} end
 Cash(S::Symbol) = Cash{S,unit(S)}()
+Cash(::Type{Currency{S}}) where {S} = Cash(S)
 Cash(::Currency{S}) where {S} = Cash(S)
 
 unit(::Cash{S,N}) where {S,N} = N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ end
         cash = Base.eval(Assets, sym)
         @test cash == Cash(ccy)
         @test cash == Cash(symbol(ccy))
-        @test currency(cash) == ccy
+        @test currency(cash) == typeof(ccy)
         @test symbol(cash) == symbol(ccy)
         @test unit(cash) == unit(ccy)
         @test code(cash) == code(ccy)
@@ -36,7 +36,7 @@ end
         CT = typeof(cash)
         position = Position{CT}(1)
         @test currency(position) == currency(cash)
-        @test currency(1cash) == ccy
+        @test currency(1cash) == typeof(ccy)
         @test 1cash == position
         @test cash * 1 == position
         @test 1cash + 1cash == Position{CT}(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-using Currencies, Instruments, Assets, FixedPointDecimals
-using Assets: USD, EUR, JPY, JOD, CNY
-using Assets: currency, symbol, unit, code, name
+using Assets; using Assets: USD, EUR, JPY, JOD, CNY
+using Currencies; using Currencies: currency, symbol, unit, code, name
+using Instruments, FixedPointDecimals
 
 using Test
 


### PR DESCRIPTION
- Simplify API (remove unnecessary methods)
- Rename `ListedEquity` -> `ListedStock` (more precise)
- Add `Stock`
- Added constructors for `Stock` and `ListedStock` that can default to USD, e.g. `Stock(:MSFT)` and `ListedStock(:NASDAQ,:MSFT)`.